### PR TITLE
fix countRealRoots/SturmHabicht in sturm.spad

### DIFF
--- a/src/algebra/sturm.spad
+++ b/src/algebra/sturm.spad
@@ -319,8 +319,7 @@ SturmHabichtPackage(R, x) : T == C where
        p2 = 0 => 0
        degree(p1::UP(x, R)) = 0 => 0
        List1 : L UP(x, R) := SturmHabichtSequence(p1, p2)
-       qp : NNI := #(List1)::NNI
-       wfunct [coefficient(p, (qp-j)::NNI) for p in List1 for j in 1..qp]
+       wfunct [leadingCoefficient p for p in List1]
 
      countRealRoots(p1) : INT == SturmHabicht(p1, 1)
 


### PR DESCRIPTION
fricas-devel discussion:
https://groups.google.com/d/msg/fricas-devel/KjNd2TbPmmM/0RhuBPTiAgAJ

The bug is:

```
(1) -> countRealRoots(x^2-1)

   (1)  2
                                                        Type: PositiveInteger
(2) -> countRealRoots(x^4-1)

   (2)  1
                                                        Type: PositiveInteger
```

Real roots of `x^4-1` are 1, -1, so `countRealRoots(x^4-1)` should be 2.

The implementation of `SturmHabichtSequence` is correct, this bug happens in sign variations counting. 
The sign of a polynomial at infinity is determinated by its leading coefficient.

Also see `rootOf, sturmNthRoot` in `reclos.spad`, it's a list of `leadingCoefficient` passed to `sturmVariationsOf`:

```
   rootOf(pol, n) ==
    ls := sturmSequence(pol)$UTIL
    pol := unitCanonical(first(ls)) -- this one is SqFR
    degree(pol) = 0 => "failed"
    numberOfMonomials(pol) = 1 => ([0, 1, monomial(1, 1)]$Rep)::%
    b := rootBound(pol)
    l1, l2 : List(TheField)
    (l1, l2) := ([] , [])
    for t in reverse(ls) repeat
      if odd?(degree(t))
      then
       (l1, l2) := (cons(leadingCoefficient(t), l1),
                  cons(-leadingCoefficient(t), l2))
      else
       (l1, l2) := (cons(leadingCoefficient(t), l1),
                  cons(leadingCoefficient(t), l2))
    res := sturmNthRoot(ls,
                        -b,
                        b,
                        sturmVariationsOf(l2)$UTIL,
                        sturmVariationsOf(l1)$UTIL,
                        n)
    res case "failed" => "failed"
    makeChar(res.low, res.high, pol)
```

After patch:

```
(1) -> countRealRoots(x^4-1)

   (1)  2
                                                        Type: PositiveInteger
```
